### PR TITLE
refactor: Some refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "enum_tags"
 version = "0.0.0"
 dependencies = [
@@ -16,6 +22,7 @@ name = "fern"
 version = "0.0.0"
 dependencies = [
  "enum_tags",
+ "num-traits",
  "paste",
  "static_assertions",
 ]
@@ -32,6 +39,15 @@ name = "libc"
 version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "paste"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license-file = "LICENSE"
 libc = "0.2.167"
 paste = "1.0.15"
 static_assertions = "1.1.0"
-syn = "2.0.90"
+syn = { version = "2.0.90", features = ["parsing"] }
 quote = "1.0.37"
 proc-macro2 = "1.0.92"
+num-traits = "0.2.19"

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 ![CI](https://github.com/ethanuppal/fernjit/actions/workflows/ci.yaml/badge.svg)
 ![Code Style](https://github.com/ethanuppal/fernjit/actions/workflows/lint.yaml/badge.svg)
 
-I'm writing a JIT compiler for a bytecode runtime (tentatively called "fern") to learn about how JITs work!
+[Utku](https://utku.sh) and I are writing a JIT compiler for a bytecode runtime (tentatively called "fern") to learn about how JITs work!

--- a/enum_tags/src/lib.rs
+++ b/enum_tags/src/lib.rs
@@ -1,20 +1,97 @@
+use std::fmt;
+
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::{format_ident, quote};
-use syn::parse_macro_input;
+use syn::{parenthesized, parse_macro_input};
+
+enum Visibility {
+    Public(Span),
+    Private,
+}
+
+impl fmt::Display for Visibility {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Public(..) => "public",
+            Self::Private => "private",
+        }
+        .fmt(f)
+    }
+}
+
+impl syn::parse::Parse for Visibility {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let identifier = input.parse::<syn::Ident>()?;
+        match identifier.to_string().as_str() {
+            "public" => Ok(Self::Public(identifier.span())),
+            "private" => Ok(Self::Private),
+            _ => Err(syn::Error::new_spanned(
+                identifier,
+                "Unexpected visibility: expected `public` or `private`",
+            )),
+        }
+    }
+}
+
+struct EnumTagsArgs {
+    visibility: Visibility,
+    repr_type: syn::Type,
+}
+
+impl syn::parse::Parse for EnumTagsArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        mod kw {
+            use syn::custom_keyword;
+
+            custom_keyword!(repr);
+        }
+
+        let visibility = input.parse()?;
+
+        input.parse::<syn::Token![,]>().map_err(|mut error| {
+            error.combine(syn::Error::new(
+                input.span(),
+                format!("Missing comma after `{}` visibility", visibility),
+            ));
+            error
+        })?;
+
+        input.parse::<kw::repr>().map_err(|mut error| {
+            error.combine(syn::Error::new(
+                input.span(),
+                format!("Missing `repr` after `{},`", visibility),
+            ));
+            error
+        })?;
+
+        let content;
+        parenthesized!(content in input);
+        let repr_type = content.parse()?;
+
+        Ok(Self {
+            visibility,
+            repr_type,
+        })
+    }
+}
 
 // TODO: make this somehow a trait implementation.
 fn impl_enum_tags(
+    enum_visibility: syn::Visibility,
     enum_name: syn::Ident,
-    repr_type: syn::Ident,
+    repr_type: syn::Type,
     variants: impl Iterator<Item = syn::Variant>,
 ) -> proc_macro2::TokenStream {
-    let mut tag_idents = Vec::new();
+    let mut tag_idents = vec![];
+    let mut match_cases = vec![];
     let mut discriminant = 0;
 
     for variant in variants {
+        let variant_name = variant.ident;
         let tag_ident = format_ident!(
             "{}_TAG",
-            variant.ident.to_string().to_ascii_uppercase()
+            variant_name.to_string().to_ascii_uppercase()
         );
 
         if let Some((_, custom_discriminant)) = variant.discriminant {
@@ -39,8 +116,27 @@ fn impl_enum_tags(
         }
 
         tag_idents.push(quote! {
-            pub const #tag_ident: #repr_type = #discriminant as _;
+            #[doc = concat!("`#[enum_tags]`-generated tag for the variant `Self::", stringify!(#variant_name), "`.")]
+            #enum_visibility const #tag_ident: #repr_type = #discriminant as _;
         });
+
+        match variant.fields {
+            syn::Fields::Named(_) => {
+                match_cases.push(quote! {
+                    Self::#variant_name { .. } => #discriminant as _
+                });
+            }
+            syn::Fields::Unnamed(_) => {
+                match_cases.push(quote! {
+                    Self::#variant_name(..) => #discriminant as _
+                });
+            }
+            syn::Fields::Unit => {
+                match_cases.push(quote! {
+                    Self::#variant_name => #discriminant as _
+                });
+            }
+        }
 
         discriminant += 1;
     }
@@ -48,13 +144,32 @@ fn impl_enum_tags(
     quote! {
         impl #enum_name {
             #(#tag_idents)*
+
+            #[doc = "`#[enum_tags]`-generated getter for this variant's tag."]
+            #enum_visibility const fn tag(&self) -> #repr_type {
+                match self {
+                    #(#match_cases),*
+                }
+            }
         }
     }
 }
 
-/// For now, assumes the enum is `#[repr(u8)]`.
+/// Constructs an `impl` for the given `enum` with constants for the
+/// discriminant value of each variant.
+///
+/// Usage examples:
+///
+/// * `#[enum_tags(public, repr(u8))]`
+/// * `#[enum_tags(private, repr(u32))]`
+///
+/// Note that the `repr` type can be any numerical type to which a `usize` can
+/// be casted to implicitly with the `as` keyword --- it is not the same as the
+/// type for which you may `#[repr(...)]` the `enum`.
 #[proc_macro_attribute]
-pub fn enum_tags(_args: TokenStream, input: TokenStream) -> TokenStream {
+pub fn enum_tags(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as EnumTagsArgs);
+
     let input_item = parse_macro_input!(input as syn::DeriveInput);
     let input_item_cloned = input_item.clone();
 
@@ -74,30 +189,17 @@ pub fn enum_tags(_args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
-    let mut repr_type = None;
-    for attr in &input_item.attrs {
-        if attr.path().is_ident("repr") {
-            let _ = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("u8") {
-                    repr_type = Some(meta.path.get_ident().cloned().unwrap());
-                }
-                Ok(())
-            });
+    let visibility = match args.visibility {
+        Visibility::Public(span) => {
+            syn::Visibility::Public(syn::token::Pub { span })
         }
-    }
-
-    let Some(repr_type) = repr_type else {
-        return syn::Error::new_spanned(
-            data_enum.enum_token,
-            "Missing #[repr(...)] attribute specifying backing type for discriminant",
-        )
-        .into_compile_error()
-        .into();
+        Visibility::Private => syn::Visibility::Inherited,
     };
 
     let tags_impl = impl_enum_tags(
+        visibility,
         input_item.ident,
-        repr_type,
+        args.repr_type,
         data_enum.variants.into_iter(),
     );
 

--- a/enum_tags/src/lib.rs
+++ b/enum_tags/src/lib.rs
@@ -1,8 +1,7 @@
 use std::fmt;
 
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
-use syn::{parenthesized, parse_macro_input};
+use quote::quote;
 
 enum Visibility {
     Public(proc_macro2::Span),
@@ -65,7 +64,7 @@ impl syn::parse::Parse for EnumTagsArgs {
         })?;
 
         let content;
-        parenthesized!(content in input);
+        syn::parenthesized!(content in input);
         let repr_type = content.parse()?;
 
         Ok(Self {
@@ -88,7 +87,7 @@ fn impl_enum_tags(
 
     for variant in variants {
         let variant_name = variant.ident;
-        let tag_ident = format_ident!(
+        let tag_ident = quote::format_ident!(
             "{}_TAG",
             variant_name.to_string().to_ascii_uppercase()
         );
@@ -167,9 +166,9 @@ fn impl_enum_tags(
 /// type for which you may `#[repr(...)]` the `enum`.
 #[proc_macro_attribute]
 pub fn enum_tags(args: TokenStream, input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(args as EnumTagsArgs);
+    let args = syn::parse_macro_input!(args as EnumTagsArgs);
 
-    let input_item = parse_macro_input!(input as syn::DeriveInput);
+    let input_item = syn::parse_macro_input!(input as syn::DeriveInput);
     let input_item_cloned = input_item.clone();
 
     let data_enum = match input_item.data {

--- a/enum_tags/src/lib.rs
+++ b/enum_tags/src/lib.rs
@@ -1,12 +1,11 @@
 use std::fmt;
 
 use proc_macro::TokenStream;
-use proc_macro2::Span;
 use quote::{format_ident, quote};
 use syn::{parenthesized, parse_macro_input};
 
 enum Visibility {
-    Public(Span),
+    Public(proc_macro2::Span),
     Private,
 }
 

--- a/enum_tags/src/lib.rs
+++ b/enum_tags/src/lib.rs
@@ -48,18 +48,17 @@ impl syn::parse::Parse for EnumTagsArgs {
         let visibility = input.parse()?;
 
         input.parse::<syn::Token![,]>().map_err(|mut error| {
-            error.combine(syn::Error::new(
-                input.span(),
-                format!("Missing comma after `{}` visibility", visibility),
-            ));
+            error.combine(input.error(format!(
+                "Missing comma after `{}` visibility",
+                visibility
+            )));
             error
         })?;
 
         input.parse::<kw::repr>().map_err(|mut error| {
-            error.combine(syn::Error::new(
-                input.span(),
-                format!("Missing `repr` after `{},`", visibility),
-            ));
+            error.combine(
+                input.error(format!("Missing `repr` after `{},`", visibility)),
+            );
             error
         })?;
 
@@ -74,7 +73,6 @@ impl syn::parse::Parse for EnumTagsArgs {
     }
 }
 
-// TODO: make this somehow a trait implementation.
 fn impl_enum_tags(
     enum_visibility: syn::Visibility,
     enum_name: syn::Ident,

--- a/fern/Cargo.toml
+++ b/fern/Cargo.toml
@@ -4,10 +4,8 @@ version.workspace = true
 edition.workspace = true
 license-file.workspace = true
 
-[features]
-validate = []
-
 [dependencies]
 paste.workspace = true
 static_assertions.workspace = true
+num-traits.workspace = true
 enum_tags = { path = "../enum_tags/" }

--- a/fern/src/arch.rs
+++ b/fern/src/arch.rs
@@ -12,8 +12,8 @@ pub const fn bitmask(bits: usize) -> Word {
 
 pub const LOCAL_ADDRESS_BITS: usize = LocalAddress::BITS as usize;
 
-pub const LOCALS_SIZE: usize = 1usize << LOCAL_ADDRESS_BITS;
-pub const CODE_SIZE: usize = 1024;
+pub const LOCALS_COUNT: usize = 1usize << LOCAL_ADDRESS_BITS;
+pub const MAX_CODE_LENGTH: usize = 1024;
 
 pub const ARGUMENT_LOCALS: Range<usize> = 0..8;
 pub const RETURN_LOCALS: Range<usize> = 0..2;

--- a/fern/src/arch.rs
+++ b/fern/src/arch.rs
@@ -3,7 +3,7 @@
 use core::ops::Range;
 
 pub type Word = u32;
-pub type InstructionAddress = usize; // TODO: better name?
+pub type InstructionAddress = usize;
 pub type LocalAddress = u8;
 
 pub const fn bitmask(bits: usize) -> Word {

--- a/fern/src/lib.rs
+++ b/fern/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (C) 2024 Ethan Uppal and Utku Melemetci. All rights reserved.
 
+#![forbid(unsafe_code)]
+
 pub mod arch;
-pub mod opcode;
+pub mod op;
 pub mod vm;

--- a/fern/src/main.rs
+++ b/fern/src/main.rs
@@ -1,3 +1,0 @@
-// Copyright (C) 2024 Ethan Uppal. All rights reserved.
-
-fn main() {}

--- a/fern/src/vm.rs
+++ b/fern/src/vm.rs
@@ -10,8 +10,6 @@ use crate::{
     op::{Op, IMM_BITS, IMM_EXT_BITS},
 };
 
-// TODO: is this uglier than the macro version?
-// TODO: if we use the newtype pattern the `AsPrimitive` won't work
 fn sign_extend_to<
     In: num_traits::Unsigned + num_traits::PrimInt + num_traits::AsPrimitive<Out>,
     Out: 'static + num_traits::Unsigned + Copy,

--- a/fern/src/vm.rs
+++ b/fern/src/vm.rs
@@ -4,28 +4,44 @@ use std::vec;
 
 use crate::{
     arch::{
-        InstructionAddress, LocalAddress, Word, ARGUMENT_LOCALS, CODE_SIZE,
-        LOCALS_SIZE, RETURN_LOCALS,
+        InstructionAddress, LocalAddress, Word, ARGUMENT_LOCALS, LOCALS_COUNT,
+        MAX_CODE_LENGTH, RETURN_LOCALS,
     },
-    opcode::{Op, IMM_BITS, IMM_EXT_BITS},
+    op::{Op, IMM_BITS, IMM_EXT_BITS},
 };
 
-macro_rules! sign_extend_to {
-    ($t:ty, $value:expr, $bits:expr) => {{
-        let value = $value as $t;
-        let sign_bit = 1 << ($bits - 1);
-        if value & sign_bit != 0 {
-            let extension = !((1 << $bits) - 1);
-            value | extension
-        } else {
-            value
-        }
-    }};
+// TODO: is this uglier than the macro version?
+// TODO: if we use the newtype pattern the `AsPrimitive` won't work
+fn sign_extend_to<
+    In: num_traits::Unsigned + num_traits::PrimInt + num_traits::AsPrimitive<Out>,
+    Out: 'static + num_traits::Unsigned + Copy,
+>(
+    value: In,
+    bits: usize,
+) -> Out {
+    let sign_bit = In::one() << (bits - 1);
+    if value & sign_bit != In::zero() {
+        let extension = !((In::one() << bits) - In::one());
+        value | extension
+    } else {
+        value
+    }
+    .as_()
 }
 
 struct StackFrame {
-    locals: [Word; LOCALS_SIZE],
+    // TODO: do we wnat this on the heap?
+    locals: [Word; LOCALS_COUNT],
     return_address: InstructionAddress,
+}
+
+impl StackFrame {
+    fn new_returning_to(return_address: InstructionAddress) -> Self {
+        Self {
+            locals: [0; LOCALS_COUNT],
+            return_address,
+        }
+    }
 }
 
 pub struct VM {
@@ -37,9 +53,7 @@ pub struct VM {
 
 #[derive(Debug)]
 pub enum VMError {
-    InvalidOp,
     InvalidArgs,
-    CodeOversized,
     InvalidIP,
 }
 
@@ -48,7 +62,7 @@ pub type VMResult = Result<(), VMError>;
 impl Default for VM {
     fn default() -> Self {
         Self {
-            code: vec![0; CODE_SIZE].into_boxed_slice(),
+            code: vec![0; MAX_CODE_LENGTH].into_boxed_slice(),
             code_length: 0,
             call_stack: vec![],
             ip: 0,
@@ -57,19 +71,22 @@ impl Default for VM {
 }
 
 impl VM {
-    pub fn load(&mut self, program: &[Op]) -> VMResult {
+    pub fn load(&mut self, program: &[Op]) {
+        // TODO: should this be an assertion or a `VMError`?
+        assert!(
+            program.len() <= MAX_CODE_LENGTH,
+            "program too large to load (length={}, max length={})",
+            program.len(),
+            MAX_CODE_LENGTH
+        );
         for (i, op) in program.iter().enumerate() {
             self.code[i] = op.encode_packed();
         }
         self.code_length = program.len();
         self.call_stack.clear();
-        self.call_stack.push(StackFrame {
-            locals: [0; LOCALS_SIZE],
-            return_address: 0, /* once the initial frame is popped, execution
-                                * stops, so it doesn't  matter what address
-                                * we have here */
-        });
-        Ok(())
+        // this return address doesn't matter because execution stops when this
+        // frame is popped
+        self.call_stack.push(StackFrame::new_returning_to(0));
     }
 
     pub fn run(&mut self) -> VMResult {
@@ -79,10 +96,6 @@ impl VM {
         Ok(())
     }
 
-    fn decode_op(&self) -> Op {
-        Op::decode_packed(self.code[self.ip]).unwrap()
-    }
-
     fn step(&mut self) -> VMResult {
         match self.decode_op() {
             Op::Mov(to, from) => {
@@ -90,7 +103,7 @@ impl VM {
                 self.jump_to(self.ip + 1)
             }
             Op::MovI(to, constant) => {
-                let extended = sign_extend_to!(Word, constant, IMM_BITS);
+                let extended = sign_extend_to(constant, IMM_BITS);
                 self.write_local(to, extended);
                 self.jump_to(self.ip + 1)
             }
@@ -100,37 +113,28 @@ impl VM {
                 self.jump_to(self.ip + 1)
             }
             Op::Ret => {
-                let frame = self.current_frame();
-                let ra = frame.return_address;
-
-                let popped = self.call_stack.pop().expect(
-                    "call stack expected to always have one frame while running.",
+                let callee_frame = self.call_stack.pop().expect(
+                    "call stack should always have one frame while running.",
                 );
-                if let Some(frame_below) = self.call_stack.last_mut() {
-                    frame_below.locals[RETURN_LOCALS]
-                        .copy_from_slice(&popped.locals[RETURN_LOCALS]);
+                let return_address = callee_frame.return_address;
+
+                if let Some(caller_frame) = self.call_stack.last_mut() {
+                    caller_frame.locals[RETURN_LOCALS]
+                        .copy_from_slice(&callee_frame.locals[RETURN_LOCALS]);
                 }
 
-                self.jump_to(ra)
+                self.jump_to(return_address)
             }
             Op::Call(offset) => {
-                let as_usize: usize = offset
-                    .try_into()
-                    .expect("illegal offset, too large for platform"); // explodes on microcontrollers
-                let extended =
-                    sign_extend_to!(InstructionAddress, as_usize, IMM_EXT_BITS);
-                let new_ip = self.ip.wrapping_add(extended);
-                // handle negative offsets
+                let new_ip =
+                    self.ip.wrapping_add(sign_extend_to(offset, IMM_EXT_BITS));
 
-                let mut new_frame = StackFrame {
-                    locals: [0; LOCALS_SIZE],
-                    return_address: self.ip + 1,
-                };
-                new_frame.locals[ARGUMENT_LOCALS].copy_from_slice(
+                let mut callee_frame =
+                    StackFrame::new_returning_to(self.ip + 1);
+                callee_frame.locals[ARGUMENT_LOCALS].copy_from_slice(
                     &self.current_frame().locals[ARGUMENT_LOCALS],
                 );
-
-                self.call_stack.push(new_frame);
+                self.call_stack.push(callee_frame);
 
                 self.jump_to(new_ip)
             }
@@ -140,14 +144,17 @@ impl VM {
         Ok(())
     }
 
+    fn decode_op(&self) -> Op {
+        Op::decode_packed(self.code[self.ip]).unwrap()
+    }
+
     fn jump_to(&mut self, new_ip: usize) -> VMResult {
         if new_ip >= self.code_length {
-            return Err(VMError::InvalidIP);
-        };
-
-        self.ip = new_ip;
-
-        Ok(())
+            Err(VMError::InvalidIP)
+        } else {
+            self.ip = new_ip;
+            Ok(())
+        }
     }
 
     fn read_local(&self, address: LocalAddress) -> Word {
@@ -159,38 +166,37 @@ impl VM {
     }
 
     fn current_frame(&self) -> &StackFrame {
-        self.call_stack.last().expect(
-            "call stack expected to always have one frame while running.",
-        )
+        self.call_stack
+            .last()
+            .expect("call stack should always have one frame while running.")
     }
 
     fn current_frame_mut(&mut self) -> &mut StackFrame {
-        self.call_stack.last_mut().expect(
-            "call stack expected to always have one frame while running.",
-        )
+        self.call_stack
+            .last_mut()
+            .expect("call stack should always have one frame while running.")
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::VM;
-    use crate::opcode::{ExtendedImmediate, Op};
+    use crate::op::{ExtendedImmediate, Op};
 
     #[test]
     fn basic_program() {
         let mut vm = VM::default();
-        vm.load(&[Op::MovI(0, 1), Op::MovI(1, 2), Op::Add(2, 0, 1), Op::Ret])
-            .expect("invalid program");
+        vm.load(&[Op::MovI(0, 1), Op::MovI(1, 2), Op::Add(2, 0, 1), Op::Ret]);
 
         for _ in 0..3 {
-            vm.step().expect("failed to run program");
+            vm.step().expect("program should run without errors")
         }
 
         assert_eq!(1, vm.current_frame().locals[0]);
         assert_eq!(2, vm.current_frame().locals[1]);
         assert_eq!(3, vm.current_frame().locals[2]);
 
-        vm.step().expect("failed to run program");
+        vm.step().expect("program should run without errors");
         assert!(vm.call_stack.is_empty());
     }
 
@@ -206,17 +212,16 @@ mod tests {
             // func add
             Op::Add(0, 0, 1),
             Op::Ret,
-        ])
-        .expect("invalid program");
+        ]);
 
         for _ in 0..5 {
-            vm.step().expect("failed to run program");
+            vm.step().expect("program should run without errors");
         }
 
         assert_eq!(3, vm.current_frame().locals[0]);
         assert_eq!(2, vm.current_frame().locals[1]);
 
-        vm.step().expect("failed to run program");
+        vm.step().expect("program should run without errors");
         assert!(vm.call_stack.is_empty());
     }
 
@@ -237,15 +242,15 @@ mod tests {
             Op::Ret,
         ];
 
-        vm.load(&program).expect("invalid program");
+        vm.load(&program);
 
         for _ in 0..7 {
-            vm.step().expect("failed to run program");
+            vm.step().expect("program should run without errors");
         }
 
         assert_eq!(6, vm.current_frame().locals[0]);
 
-        vm.step().expect("failed to run program");
+        vm.step().expect("program should run without errors");
         assert!(vm.call_stack.is_empty());
     }
 }


### PR DESCRIPTION
Changes:
- Reworks the `#[enum_tags]` macro
- Renames some functions/variables
- Removed redundant VM errors and error checking

Changes to discuss:
- [x] Switches from a macro for sign extension to bringing back `num-traits` (which you had introduced before I think)
- [x] We now `panic!` when trying to load a program too large
- [x] The other `// TODO`s