### PR TITLE
Rename crates to publish to `crates.io`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,19 +12,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "fern"
+name = "fern-jit"
+version = "0.0.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fern-vm"
 version = "0.0.0"
 dependencies = [
  "enum_tags",
  "paste",
  "static_assertions",
-]
-
-[[package]]
-name = "jit"
-version = "0.0.0"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/fern/Cargo.toml
+++ b/fern/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fern"
+name = "fern-vm"
 version.workspace = true
 edition.workspace = true
 license-file.workspace = true

--- a/jit/Cargo.toml
+++ b/jit/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jit"
+name = "fern-jit"
 version.workspace = true
 edition.workspace = true
 license-file.workspace = true


### PR DESCRIPTION
- "fern" -> "fern-vm"
- "jit" -> "fern-jit"