### PR TITLE
fix: Publish to `crates.io`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 4
 
 [[package]]
-name = "enum_tags"
+name = "fern-enum-tags"
 version = "0.0.0"
 dependencies = [
  "proc-macro2",
@@ -22,7 +22,7 @@ dependencies = [
 name = "fern-vm"
 version = "0.0.0"
 dependencies = [
- "enum_tags",
+ "fern-enum-tags",
  "paste",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,19 +12,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "fern"
+name = "fern-jit"
+version = "0.0.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fern-vm"
 version = "0.0.0"
 dependencies = [
  "enum_tags",
  "paste",
  "static_assertions",
-]
-
-[[package]]
-name = "jit"
-version = "0.0.0"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ static_assertions = "1.1.0"
 syn = "2.0.90"
 quote = "1.0.37"
 proc-macro2 = "1.0.92"
+enum_tags = { path = "enum_tags/", package = "fern-enum-tags", version = "0.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["enum_tags", "fern", "jit"]
 resolver = "2"
 
 [workspace.package]
+repository = "https://github.com/ethanuppal/fernjit"
 version = "0.0.0"
 edition = "2021"
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 
 [workspace.package]
 repository = "https://github.com/ethanuppal/fernjit"
+readme = "README.md"
 version = "0.0.0"
 edition = "2021"
 license-file = "LICENSE"

--- a/enum_tags/Cargo.toml
+++ b/enum_tags/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "enum_tags"
+description = "Variant tags for enums with fields too"
+repository.workspace = true
 version.workspace = true
 edition.workspace = true
 license-file.workspace = true

--- a/enum_tags/Cargo.toml
+++ b/enum_tags/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "enum_tags"
+name = "fern-enum-tags"
 description = "Variant tags for enums with fields too"
 repository.workspace = true
 version.workspace = true

--- a/fern/Cargo.toml
+++ b/fern/Cargo.toml
@@ -10,4 +10,4 @@ validate = []
 [dependencies]
 paste.workspace = true
 static_assertions.workspace = true
-enum_tags = { path = "../enum_tags/", package = "fern-enum-tags" }
+enum_tags.workspace = true

--- a/fern/Cargo.toml
+++ b/fern/Cargo.toml
@@ -10,4 +10,4 @@ validate = []
 [dependencies]
 paste.workspace = true
 static_assertions.workspace = true
-enum_tags = { path = "../enum_tags/" }
+enum_tags = { path = "../enum_tags/", package = "fern-enum-tags" }

--- a/fern/Cargo.toml
+++ b/fern/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "fern-vm"
+description = "The fern bytecode runtime"
+repository.workspace = true
+readme.workspace = true
 version.workspace = true
 edition.workspace = true
 license-file.workspace = true

--- a/fern/Cargo.toml
+++ b/fern/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fern"
+name = "fern-vm"
 version.workspace = true
 edition.workspace = true
 license-file.workspace = true

--- a/fern/src/opcode.rs
+++ b/fern/src/opcode.rs
@@ -1,6 +1,6 @@
 // Copyright (C) 2024 Ethan Uppal. All rights reserved.
 
-use fern_enum_tags::enum_tags;
+use enum_tags::enum_tags;
 
 use crate::arch::{bitmask, LocalAddress, Word, LOCAL_ADDRESS_BITS};
 

--- a/fern/src/opcode.rs
+++ b/fern/src/opcode.rs
@@ -1,6 +1,6 @@
 // Copyright (C) 2024 Ethan Uppal. All rights reserved.
 
-use enum_tags::enum_tags;
+use fern_enum_tags::enum_tags;
 
 use crate::arch::{bitmask, LocalAddress, Word, LOCAL_ADDRESS_BITS};
 

--- a/jit/Cargo.toml
+++ b/jit/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "fern-jit"
+description = "JIT compiler for the fern bytecode runtime"
+repository.workspace = true
+readme.workspace = true
 version.workspace = true
 edition.workspace = true
 license-file.workspace = true

--- a/jit/Cargo.toml
+++ b/jit/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jit"
+name = "fern-jit"
 version.workspace = true
 edition.workspace = true
 license-file.workspace = true


### PR DESCRIPTION
Fixes a bunch of configuration stuff needed to actually publish. Also, renames "enum_tags" -> "fern-enum-tags".