### PR TITLE
ci: Fix CI on main

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Rust Caching


### PR DESCRIPTION
Somehow it broke on `main` and not `cov` when I merged in #17.